### PR TITLE
✨ feat(config): override config bools with env vars

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -34,16 +34,34 @@ pub struct Opt {
     pub config: Option<String>,
 
     /// Suppress progress messages.
-    #[arg(short = 'q', long, env = "GIT_SUMI_QUIET")]
-    pub quiet: bool,
+    #[arg(
+        short = 'q',
+        num_args = 0,
+        default_missing_value = "true",
+        long,
+        env = "GIT_SUMI_QUIET"
+    )]
+    pub quiet: Option<bool>,
 
     /// Process each non-empty line as an individual commit.
-    #[arg(short = 's', long, env = "GIT_SUMI_SPLIT_LINES")]
-    pub split_lines: bool,
+    #[arg(
+        short = 's',
+        long,
+        env = "GIT_SUMI_SPLIT_LINES",
+        num_args = 0,
+        default_missing_value = "true"
+    )]
+    pub split_lines: Option<bool>,
 
     /// Display the parsed commit message.
-    #[arg(short = 'd', long, env = "GIT_SUMI_DISPLAY")]
-    pub display: bool,
+    #[arg(
+        short = 'd',
+        long,
+        env = "GIT_SUMI_DISPLAY",
+        num_args = 0,
+        default_missing_value = "true"
+    )]
+    pub display: Option<bool>,
 
     /// Specify the output format for displaying the parsed commit message.
     /// Options: "cli", "table", "json", "toml". Default: "cli"
@@ -59,23 +77,47 @@ pub struct Opt {
     pub force: bool,
 
     /// Follow Conventional Commits format.
-    #[arg(short = 'C', long, env = "GIT_SUMI_CONVENTIONAL", default_value_ifs([
-        ("types_allowed", ArgPredicate::IsPresent, Some("true")),
-        ("scopes_allowed", ArgPredicate::IsPresent, Some("true")),
-        ]), help_heading = "Rules")]
-    pub conventional: bool,
+    #[arg(short = 'C',
+        long,
+        env = "GIT_SUMI_CONVENTIONAL",
+        num_args = 0,
+        default_missing_value = "true",
+        default_value_ifs([
+            ("types_allowed", ArgPredicate::IsPresent, Some("true")),
+            ("scopes_allowed", ArgPredicate::IsPresent, Some("true")),
+            ]),
+        help_heading = "Rules")]
+    pub conventional: Option<bool>,
 
     /// Use the imperative mood in the description.
-    #[arg(short = 'I', long, env = "GIT_SUMI_IMPERATIVE", help_heading = "Rules")]
-    pub imperative: bool,
+    #[arg(
+        short = 'I',
+        long,
+        env = "GIT_SUMI_IMPERATIVE",
+        num_args = 0,
+        default_missing_value = "true"
+    )]
+    pub imperative: Option<bool>,
 
     /// Include one valid Gitmoji.
-    #[arg(short = 'G', long, env = "GIT_SUMI_GITMOJI", help_heading = "Rules")]
-    pub gitmoji: bool,
+    #[arg(
+        short = 'G',
+        long,
+        env = "GIT_SUMI_GITMOJI",
+        num_args = 0,
+        default_missing_value = "true"
+    )]
+    pub gitmoji: Option<bool>,
 
     /// Disallow leading/trailing whitespace and consecutive spaces.
-    #[arg(short = 'W', long, env = "GIT_SUMI_WHITESPACE", help_heading = "Rules")]
-    pub whitespace: bool,
+    #[arg(
+        short = 'W',
+        long,
+        env = "GIT_SUMI_WHITESPACE",
+        num_args = 0,
+        default_missing_value = "true"
+    )]
+    pub whitespace: Option<bool>,
 
     /// Commit description must start with the selected case.
     /// Options: "lower", "upper", "any". Default: "any".
@@ -89,8 +131,14 @@ pub struct Opt {
     pub description_case: Option<DescriptionCase>,
 
     /// Do not end commit header with a period.
-    #[arg(short = 'P', long, env = "GIT_SUMI_NO_PERIOD", help_heading = "Rules")]
-    pub no_period: bool,
+    #[arg(
+        short = 'P',
+        long,
+        env = "GIT_SUMI_NO_PERIOD",
+        num_args = 0,
+        default_missing_value = "true"
+    )]
+    pub no_period: Option<bool>,
 
     /// Limit the header to the specified length.
     #[arg(short = 'H', long, env = "GIT_SUMI_MAX_HEADER_LENGTH", value_parser = clap::value_parser!(usize), help_heading = "Rules")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,8 +143,8 @@ pub fn count_active_rules(config: &Config) -> usize {
 /// - For lists, updates the `Config` field only if the list is not empty.
 macro_rules! update_field {
     ($config_field:expr, $self_field:expr) => {
-        if $self_field {
-            $config_field = true;
+        if let Some(val) = $self_field {
+            $config_field = val;
         }
     };
     ($config_field:expr, $self_field:expr, option) => {

--- a/tests/lint/test_config.rs
+++ b/tests/lint/test_config.rs
@@ -3,6 +3,7 @@ extern crate tempfile;
 use super::contains;
 use super::run_isolated_git_sumi;
 use super::Command;
+use predicates::prelude::*;
 use std::fs;
 use tempfile::tempdir;
 
@@ -157,6 +158,32 @@ fn error_fail_override_config_file_gitmoji() {
         .assert()
         .failure()
         .stderr(contains("Header must contain exactly 1 emoji, found 2"));
+}
+
+#[test]
+fn success_override_quiet_with_env_var() {
+    let mut cmd = Command::cargo_bin("git-sumi").unwrap();
+    cmd.env("GIT_SUMI_QUIET", "false") // Should override config.
+        .arg("--config")
+        .arg("tests/resources/good_config_ciqf.toml") // Sets quiet = true.
+        .arg("Commit message")
+        .assert()
+        .success()
+        .stdout(contains("Input"))
+        .stdout(contains("passed"));
+}
+
+#[test]
+fn success_override_gitmoji_with_env_var() {
+    let mut cmd = Command::cargo_bin("git-sumi").unwrap();
+    cmd.env("GIT_SUMI_GITMOJI", "false") // Override gitmoji = true in config.
+        .arg("--config")
+        .arg("tests/resources/good_config_gitmoji.toml")
+        .arg("-d") // Needs a rule/display/commit.
+        .arg("refactor(HTML): remove unused code")
+        .assert()
+        .success()
+        .stderr(contains("Header must contain exactly 1 emoji").not());
 }
 
 #[test]


### PR DESCRIPTION
<!--
  Thank you for contributing to git-sumi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

This PR introduces the ability to override boolean configuration flags through environment variables. Example, with `sumi.toml` containing `quiet = true`, you can do:

```bash
GIT_SUMI_QUIET=false git sumi '👷 misc(CI): rename git-sumi job'
```

And quiet will be correctly set to `false`:

```
💬 Input: "👷 misc(CI): rename git-sumi job"
✅ All 10 checks passed.
```

---

### How has this been tested?

- [X] Manual tests
- [ ] Unit tests
- [X] Integration tests

---

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

### Checklist

- [X] I have read the [**contributing guidelines**](https://github.com/welpo/git-sumi/blob/main/CONTRIBUTING.md).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I have formatted the code with `cargo fmt`.
- [ ] My change requires updating the documentation.
- [ ] I have updated the documentation accordingly.
