### PR TITLE
🐛 fix: ignore comment lines in commit messages

### DIFF
--- a/tests/lint/test_display.rs
+++ b/tests/lint/test_display.rs
@@ -4,7 +4,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::Value;
 
-const COMMIT_MESSAGE: &str = "🐛 fix(Scope)!: short description\n\nLonger body description\n\nBREAKING CHANGE: breaking description\nFooter1: value1\nFooter2: value2\n\n#123, ce6df36";
+const COMMIT_MESSAGE: &str = "🐛 fix(Scope)!: short description\n\nLonger body description\n\nBREAKING CHANGE: breaking description\nFooter1: value1\nFooter2: value2\n\nFixes #123, ce6df36";
 
 fn assert_table_output(cmd: &mut Command) {
     cmd.assert()
@@ -64,7 +64,7 @@ fn success_display_format_toml() {
 fn success_display_format_json() {
     let mut cmd = run_isolated_git_sumi("");
 
-    let commit_message = "✨ feat(CrimeAndPunishment): Add Raskolnikov's internal monologue\n\nIntroduces the new chapter where Raskolnikov wrestles with his conscience.\n\nBREAKING CHANGE: New perspective on morality introduced.\nTranslator: Garnett\nPublisher: Penguin\n#1866";
+    let commit_message = "✨ feat(CrimeAndPunishment): Add Raskolnikov's internal monologue\n\nIntroduces the new chapter where Raskolnikov wrestles with his conscience.\n\nBREAKING CHANGE: New perspective on morality introduced.\nTranslator: Garnett\nPublisher: Penguin\nFixes #1866";
 
     let output = cmd
         .arg("-dCGqf")
@@ -92,7 +92,8 @@ fn success_display_format_json() {
     let expected_footers: Value = serde_json::json!([
         "BREAKING CHANGE:New perspective on morality introduced.",
         "Translator:Garnett",
-        "Publisher:Penguin\n#1866"
+        "Publisher:Penguin",
+        "Fixes #1866"
     ]);
     assert_eq!(parsed["footers"], expected_footers);
     assert_eq!(parsed["is_breaking"], true);
@@ -137,12 +138,11 @@ fn success_display_format_markdown() {
         .stdout(contains("| Key"))
         .stdout(contains("| Value"))
         .stdout(contains("| Gitmoji              | 🐛"))
-        .stdout(contains("|----------------------|----------------------------------------------------------------------|"))
         .stdout(contains("| Scope                | Scope"))
         .stdout(contains("| Description          | short description"))
         .stdout(contains("| Body                 | Longer body description "))
         .stdout(contains(
-            "| Footers              | BREAKING CHANGE:breaking description, Footer1:value1, Footer2:value2 |",
+            "| Footers              | BREAKING CHANGE:breaking description, Footer1:value1, Footer2:value2, Fixes #123, ce6df36 |",
         ))
         .stdout(contains("| Is breaking          | true "))
         .stdout(contains("| Breaking description | breaking description "))

--- a/tests/lint/test_single_rule.rs
+++ b/tests/lint/test_single_rule.rs
@@ -106,6 +106,16 @@ fn error_invalid_whitespace() {
 }
 
 #[test]
+fn success_ignore_comments() {
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("-W")
+        // If the comment weren't ignored, git-sumi would complain about the adjacent spaces in the second line.
+        .arg("feat: adds feature\n\n#       modified:   src/lib.rs")
+        .assert()
+        .success();
+}
+
+#[test]
 fn success_non_letter_cant_be_capitalised() {
     let test_cases = [" space", "✅ emoji", "1 number"];
     for &test_case in test_cases.iter() {


### PR DESCRIPTION
<!--
  Thank you for contributing to git-sumi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

This PR introduces a fix to skip linting comment lines in commit messages, aligning git-sumi's behaviour to Git's standards.

---

### How has this been tested?

- [ ] Manual tests
- [ ] Unit tests
- [X] Integration tests

---

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

### Checklist

- [X] I have read the [**contributing guidelines**](https://github.com/welpo/git-sumi/blob/main/CONTRIBUTING.md).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I have formatted the code with `cargo fmt`.
- [ ] My change requires updating the documentation.
- [ ] I have updated the documentation accordingly.
