### PR TITLE
✨ feat: support reading commit message from a file

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -24,6 +24,14 @@ pub struct Opt {
     )]
     pub init: Option<InitOption>,
 
+    #[arg(
+        long = "file",
+        value_name = "FILE",
+        help = "Read commit message from file",
+        conflicts_with = "commit_message"
+    )]
+    pub commit_file: Option<String>,
+
     /// Outputs enabled rules' description as bash comments for the prepare-commit-msg hook.
     #[arg(long, num_args = 0, hide = true)]
     pub prepare_commit_message: bool,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,9 @@ pub enum SumiError {
     #[error("{details}")]
     GeneralError { details: String },
 
+    #[error("Failed to read commit message from file '{path}': {error}")]
+    CommitFileError { path: String, error: String },
+
     #[error("{lines_with_errors} out of {total_lines} {line_or_lines} failed linting. See the errors above")]
     SplitLinesErrors {
         lines_with_errors: usize,

--- a/tests/lint/mod.rs
+++ b/tests/lint/mod.rs
@@ -3,6 +3,7 @@ mod test_commit_changes;
 mod test_config;
 mod test_conventional_commits;
 mod test_display;
+mod test_file_input;
 mod test_gitmoji;
 mod test_single_rule;
 

--- a/tests/lint/test_file_input.rs
+++ b/tests/lint/test_file_input.rs
@@ -1,0 +1,84 @@
+use crate::run_isolated_git_sumi;
+use predicates::str::contains;
+use tempfile::tempdir;
+
+#[test]
+fn success_read_from_file() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("commit-msg.txt");
+    std::fs::write(&file_path, "feat: add new feature").unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--file")
+        .arg(file_path)
+        .arg("-C")
+        .assert()
+        .success();
+}
+
+#[test]
+fn error_nonexistent_file() {
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--file")
+        .arg("nonexistent-file.txt")
+        .arg("-C")
+        .assert()
+        .failure()
+        .stderr(contains(
+            "Could not read commit message from 'nonexistent-file.txt'",
+        ));
+}
+
+#[test]
+fn error_empty_file() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("empty.txt");
+    std::fs::write(&file_path, "").unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--file")
+        .arg(file_path)
+        .arg("-C")
+        .assert()
+        .failure()
+        .stderr(contains("Header must not be empty"));
+}
+
+#[test]
+fn error_conflict_file_and_message() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("commit.txt");
+    std::fs::write(&file_path, "feat: test").unwrap();
+
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--file")
+        .arg(file_path)
+        .arg("direct message")
+        .assert()
+        .failure()
+        .stderr(contains("cannot be used with"));
+}
+
+#[test]
+fn success_file_with_comments() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("commit-with-comments.txt");
+    std::fs::write(&file_path, "feat: add feature\n# This is a comment\n").unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--file")
+        .arg(file_path)
+        .arg("-C")
+        .assert()
+        .success();
+}
+
+#[test]
+fn success_file_with_multiline() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("multiline.txt");
+    std::fs::write(&file_path, "feat: add feature\n\nDetailed description").unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--file")
+        .arg(file_path)
+        .arg("-C")
+        .assert()
+        .success();
+}

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -38,6 +38,8 @@ git-sumi [OPTIONS] [--] [COMMIT_MESSAGE]
         Path to a TOML configuration file [env: GIT_SUMI_CONFIG=]
 -f, --format <FORMAT>
         Sets display format: cli, json, table, toml [env: GIT_SUMI_FORMAT=]
+    --file <FILE>
+        Read commit message from file
 ```
 
 ### Rules


### PR DESCRIPTION
<!--
  Thank you for contributing to git-sumi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Add support for reading commit messages from a file via a new `--file` flag. This allows direct input of commit messages from files as an alternative to command-line arguments or stdin.

### Related issue

#179

---

### How has this been tested?

- [x] Manual tests
- [ ] Unit tests
- [x] Integration tests

Added comprehensive test suite in `tests/lint/test_file_input.rs` covering:
- Reading valid files
- Handling empty files
- Processing files with comments
- Handling multiline messages
- Error cases

---

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [x] Documentation update
- [ ] Other (please describe below)

---

### Checklist

- [x] I have read the [**contributing guidelines**](https://github.com/welpo/git-sumi/blob/main/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I have formatted the code with `cargo fmt`.
- [x] My change requires updating the documentation.
- [x] I have updated the documentation accordingly.
