### PR TITLE
✨ feat: add option to remove header pattern before validation

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -224,4 +224,16 @@ pub struct Opt {
         help = config_descriptions::HEADER_PATTERN.short
     )]
     pub header_pattern: Option<String>,
+
+    /// Remove header pattern before running other validation rules.
+    #[arg(
+        long,
+        short = 'X',
+        env = "GIT_SUMI_STRIP_HEADER_PATTERN",
+        num_args = 0,
+        default_missing_value = "true",
+        help_heading = "Rules",
+        help = config_descriptions::STRIP_HEADER_PATTERN.short
+    )]
+    pub strip_header_pattern: Option<bool>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub struct Config {
     pub scopes_allowed: Vec<String>,
     pub types_allowed: Vec<String>,
     pub header_pattern: String,
+    pub strip_header_pattern: bool,
 }
 
 pub trait Configurable {
@@ -193,6 +194,11 @@ fn rules_metadata<'a>() -> Vec<RuleMeta<'a>> {
             description: HEADER_PATTERN.short,
             current_value: Box::new(|c| c.header_pattern.clone()),
         },
+        RuleMeta {
+            is_modified: Box::new(|c, d| c.strip_header_pattern != d.strip_header_pattern),
+            description: STRIP_HEADER_PATTERN.short,
+            current_value: Box::new(|c| c.strip_header_pattern.to_string()),
+        },
     ]
 }
 
@@ -243,6 +249,7 @@ impl Configurable for Opt {
         update_field!(config.scopes_allowed, self.scopes_allowed, list);
         update_field!(config.types_allowed, self.types_allowed, list);
         update_field!(config.header_pattern, self.header_pattern, option);
+        update_field!(config.strip_header_pattern, self.strip_header_pattern);
     }
 }
 
@@ -443,6 +450,7 @@ impl Config {
             ("scopes_allowed", (&SCOPES_ALLOWED, true)),
             ("types_allowed", (&TYPES_ALLOWED, true)),
             ("header_pattern", (&HEADER_PATTERN, true)),
+            ("strip_header_pattern", (&STRIP_HEADER_PATTERN, true)),
         ];
 
         let config_comments: HashMap<&str, String> = config_keys_and_rules

--- a/src/lint/constants/config_descriptions.rs
+++ b/src/lint/constants/config_descriptions.rs
@@ -89,3 +89,8 @@ pub const HEADER_PATTERN: RuleDescription = RuleDescription {
     short: "Header must match regex pattern",
     extra: Some("Example: '^JIRA-\\d+:'"),
 };
+
+pub const STRIP_HEADER_PATTERN: RuleDescription = RuleDescription {
+    short: "Remove header pattern before running other validation rules",
+    extra: None,
+};

--- a/sumi.toml
+++ b/sumi.toml
@@ -55,3 +55,6 @@ types_allowed = ["feat", "fix", "docs", "refactor", "test", "chore", "misc"]
 # Rule: Header must match regex pattern.
 # Example: '^JIRA-\d+:'.
 header_pattern = '^([\p{Emoji_Presentation}\p{Extended_Pictographic}](?:\u{FE0F})?\u{200D}?) \w' # The first character must be an emoji.
+
+# Rule: Remove header pattern before running other validation rules.
+strip_header_pattern = false

--- a/tests/lint/mod.rs
+++ b/tests/lint/mod.rs
@@ -5,6 +5,7 @@ mod test_conventional_commits;
 mod test_display;
 mod test_file_input;
 mod test_gitmoji;
+mod test_header_pattern_stripping;
 mod test_single_rule;
 
 use super::contains;

--- a/tests/lint/test_config.rs
+++ b/tests/lint/test_config.rs
@@ -746,3 +746,12 @@ fn success_initialize_all_hooks() {
         "The prepare-commit-msg hook should be created."
     );
 }
+
+#[test]
+fn error_no_rules_enabled() {
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("test commit message")
+        .assert()
+        .failure()
+        .stderr(contains("No rules enabled"));
+}

--- a/tests/lint/test_config.rs
+++ b/tests/lint/test_config.rs
@@ -390,7 +390,10 @@ types_allowed = []
 
 # Rule: Header must match regex pattern.
 # Example: '^JIRA-\d+:'.
-header_pattern = """#
+header_pattern = ""
+
+# Rule: Remove header pattern before running other validation rules.
+strip_header_pattern = false"#
 }
 
 #[test]

--- a/tests/lint/test_header_pattern_stripping.rs
+++ b/tests/lint/test_header_pattern_stripping.rs
@@ -1,0 +1,204 @@
+extern crate tempfile;
+
+use super::contains;
+use super::run_isolated_git_sumi;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_header_pattern_with_strip_disabled_backwards_compatibility() {
+    // Test backwards compatibility - old behaviour should be preserved
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+whitespace = true
+imperative = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    // With strip_header_pattern disabled (default), this should pass
+    // because whitespace and imperative checks run on full message
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("JIRA-123 fixed the bug")
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_header_pattern_with_stripping_enabled_imperative_fails() {
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+whitespace = true
+imperative = true
+strip_header_pattern = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("JIRA-123 fixed the bug")
+        .assert()
+        .failure()
+        .stderr(contains("non-imperative verb: 'fixed'"));
+}
+
+#[test]
+fn test_header_pattern_with_stripping_enabled_whitespace_fails() {
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+whitespace = true
+strip_header_pattern = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    // With stripping enabled, extra spaces after pattern removal should fail
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("JIRA-123  fixed the bug") // double space after JIRA-123
+        .assert()
+        .failure()
+        .stderr(contains("Leading space"));
+}
+
+#[test]
+fn test_header_pattern_imperative_validation_after_stripping() {
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+imperative = true
+strip_header_pattern = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("JIRA-123 fixed the bug")
+        .assert()
+        .failure()
+        .stderr(contains("non-imperative verb: 'fixed'"));
+}
+
+#[test]
+fn test_header_pattern_with_stripping_enabled_valid_case() {
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+whitespace = true
+imperative = true
+strip_header_pattern = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("JIRA-123 fix the bug")
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_header_pattern_validation_works() {
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("XYZ-123 fix the bug")
+        .assert()
+        .failure()
+        .stderr(contains("Header does not match the required pattern"));
+}
+
+#[test]
+fn test_strip_with_no_header_pattern_does_nothing() {
+    let config = r#"
+whitespace = true
+imperative = true
+strip_header_pattern = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("  fixed the bug")
+        .assert()
+        .failure()
+        .stderr(contains("Leading space"));
+}
+
+#[test]
+fn test_header_pattern_with_multiline_commit() {
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+whitespace = true
+strip_header_pattern = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    let commit_msg =
+        "JIRA-123  fix the bug\n\nThis is a detailed description\nwith multiple lines.";
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg(commit_msg)
+        .assert()
+        .failure()
+        .stderr(contains("Leading space"));
+}
+
+#[test]
+fn test_header_length_validation_uses_full_header_with_pattern() {
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+max_header_length = 20
+strip_header_pattern = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    // Full header is 25 chars: "JIRA-123 fix the bug here"
+    // Should fail length check on full header even though stripped version would be shorter
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("JIRA-123 fix the bug here")
+        .assert()
+        .failure()
+        .stderr(contains("too long"));
+}
+
+#[test]
+fn test_header_length_validation_passes_when_full_header_within_limit() {
+    let config = r#"
+header_pattern = "^JIRA-\\d+ "
+max_header_length = 30
+imperative = true
+strip_header_pattern = true
+"#;
+    let tmp_dir = tempdir().unwrap();
+    let config_path = tmp_dir.path().join("sumi.toml");
+    fs::write(&config_path, config).unwrap();
+    // Full header is 18 chars: "JIRA-123 fix bug" - should pass length
+    // Stripped version "fix bug" should pass imperative
+    let mut cmd = run_isolated_git_sumi("");
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("JIRA-123 fix bug")
+        .assert()
+        .success();
+}

--- a/website/docs/rules.md
+++ b/website/docs/rules.md
@@ -250,3 +250,36 @@ header_pattern = '^JIRA-\d+:'
 :::tip
 It's a good practice to test your regular expressions using a [regex tester](https://regex101.com/) or a similar tool before enforcing them with git-**sumi**.
 :::
+
+## Strip header pattern
+
+- **Description**: When enabled, removes the matched header pattern before running content validation rules like `whitespace`, `imperative`, and `description_case`. Format validation rules like `max_header_length` and `no_period` still use the complete header.
+
+- **Why it matters**: Useful when using prefix patterns (like JIRA ticket numbers) where you want content validation to apply to the actual commit description rather than the full formatted header.
+
+- **`sumi.toml` identifier**: `strip_header_pattern`
+
+- **Command line usage**: Long option: `--strip-header-pattern`, Short option: `-X`
+
+- **Environment variable**: `GIT_SUMI_STRIP_HEADER_PATTERN`
+
+- **Type of value**: Boolean (e.g., `true`)
+
+- **Default value**: `false`
+
+- **Example**: Set `strip_header_pattern = true` in `sumi.toml`, or use `git sumi --strip-header-pattern` or `git sumi -X`.
+
+**Example usage:**
+
+```toml
+header_pattern = "^JIRA-\\d+ "
+imperative = true
+whitespace = true
+strip_header_pattern = true
+```
+
+With this configuration:
+
+- `"JIRA-123 fixed bug"` → fails imperative check (validates "fixed bug")
+- `"JIRA-123  fix bug"` → fails whitespace check (validates " fix bug")
+- `"JIRA-123 fix bug"` → passes all checks


### PR DESCRIPTION
<!--
  Thank you for contributing to git-sumi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Add `strip_header_pattern` feature to enable content validation after header pattern removal. This new boolean option allows users to strip header patterns (like JIRA ticket prefixes) before running validation rules like `whitespace`, `imperative`, and `description_case`, while format validation rules like `max_header_length` and `no_period` still use the complete header.

### Related issue

Resolves #298

---

### How has this been tested?

- [X] Manual tests
- [ ] Unit tests
- [X] Integration tests

---

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

### Checklist

- [x] I have read the [**contributing guidelines**](https://github.com/welpo/git-sumi/blob/main/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I have formatted the code with `cargo fmt`.
- [x] My change requires updating the documentation.
- [x] I have updated the documentation accordingly.