### PR TITLE
🐛 fix(cli): expose enum values to shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
  "strum_macros",
  "tabled",
  "tempfile",
@@ -699,12 +698,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ log = "0.4.21"
 regex = "1.10.4"
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
-strum = "0.28.0"
 strum_macros = "0.28.0"
 tabled = { version = "0.21.0", default-features = false, features = ["std"] }
 thiserror = "2.0.17"

--- a/src/args.rs
+++ b/src/args.rs
@@ -20,6 +20,8 @@ pub struct Opt {
         num_args = 0..=1,
         required = false,
         default_missing_value = "config",
+        value_enum,
+        ignore_case = true,
         help = config_descriptions::INIT
     )]
     pub init: Option<InitOption>,
@@ -85,6 +87,8 @@ pub struct Opt {
     #[arg(short = 'f',
         long,
         env = "GIT_SUMI_FORMAT",
+        value_enum,
+        ignore_case = true,
         help = config_descriptions::FORMAT.short
     )]
     pub format: Option<ParsedCommitDisplayFormat>,
@@ -177,6 +181,8 @@ pub struct Opt {
         long,
         env = "GIT_SUMI_DESCRIPTION_CASE",
         value_name = "CASE",
+        value_enum,
+        ignore_case = true,
         help_heading = "Rules",
         help = config_descriptions::DESCRIPTION_CASE.short
     )]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::lint::constants::config_descriptions::*;
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -7,9 +8,7 @@ use std::io::{self, BufReader, Read, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use strum::IntoEnumIterator;
-use strum_macros::{AsRefStr, EnumIter};
+use strum_macros::AsRefStr;
 
 use super::SumiError;
 use crate::args::Opt;
@@ -42,7 +41,7 @@ pub trait Configurable {
 }
 
 /// Display format for the parsed commit message.
-#[derive(Debug, Clone, Serialize, Deserialize, EnumIter, AsRefStr, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, ValueEnum, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ParsedCommitDisplayFormat {
     #[default]
@@ -52,7 +51,7 @@ pub enum ParsedCommitDisplayFormat {
     Toml,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, EnumIter, AsRefStr, PartialEq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsRefStr, ValueEnum, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum DescriptionCase {
@@ -62,70 +61,13 @@ pub enum DescriptionCase {
     Upper,
 }
 
-impl FromStr for ParsedCommitDisplayFormat {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ParsedCommitDisplayFormat::iter()
-            .find(|variant| s.eq_ignore_ascii_case(variant.as_ref()))
-            .ok_or_else(|| {
-                format!(
-                    "Unknown format '{}'. Supported formats: {}",
-                    s,
-                    ParsedCommitDisplayFormat::iter()
-                        .map(|v| v.as_ref().to_lowercase())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            })
-    }
-}
-
-impl FromStr for DescriptionCase {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        DescriptionCase::iter()
-            .find(|variant| s.eq_ignore_ascii_case(variant.as_ref()))
-            .ok_or_else(|| {
-                format!(
-                    "Unknown case '{}'. Supported cases: {}",
-                    s,
-                    DescriptionCase::iter()
-                        .map(|v| v.as_ref().to_lowercase())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            })
-    }
-}
-
 /// Options to initialise git-sumi config.
-#[derive(Debug, Clone, Serialize, Deserialize, EnumIter, AsRefStr)]
+#[derive(Debug, Clone, Serialize, Deserialize, ValueEnum)]
 pub enum InitOption {
-    #[strum(serialize = "commit-msg")]
     CommitMsg,
     Config,
     Hooks,
-    #[strum(serialize = "prepare-commit-msg")]
     PrepareCommitMsg,
-}
-
-impl FromStr for InitOption {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        InitOption::iter()
-            .find(|variant| s.eq_ignore_ascii_case(variant.as_ref()))
-            .ok_or_else(|| {
-                format!(
-                    "Unknown option '{}'. Supported options: {}",
-                    s,
-                    InitOption::iter()
-                        .map(|v| v.as_ref().to_lowercase())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            })
-    }
 }
 
 type IsModifiedFn<'a> = Box<dyn Fn(&Config, &Config) -> bool + 'a>;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -20,19 +20,16 @@ fn run_isolated_git_sumi(subcommand: &str) -> Command {
 }
 
 #[test]
-fn success_bash_completion() {
-    let mut cmd = run_isolated_git_sumi("");
-    let output = cmd
-        .arg("--generate-shell-completion")
-        .arg("bash")
-        .output()
-        .unwrap();
+fn success_shell_completion_generation() {
+    for shell in ["bash", "elvish", "fish", "powershell", "zsh"] {
+        let mut cmd = run_isolated_git_sumi("");
+        let output = cmd
+            .arg("--generate-shell-completion")
+            .arg(shell)
+            .output()
+            .unwrap();
 
-    assert!(output.status.success());
-
-    let stdout = String::from_utf8(output.stdout).unwrap();
-
-    assert!(stdout.contains("_git-sumi() {"));
-    assert!(stdout.contains("COMPREPLY=()"));
-    assert!(stdout.contains("complete -F _git-sumi -o nosort -o bashdefault -o default git-sumi"));
+        assert!(output.status.success());
+        assert!(!output.stdout.is_empty());
+    }
 }

--- a/tests/lint/test_config.rs
+++ b/tests/lint/test_config.rs
@@ -423,7 +423,9 @@ fn error_invalid_init_value() {
         .arg("everything")
         .assert()
         .failure()
-        .stderr(contains("Supported options: "));
+        .stderr(contains(
+            "possible values: commit-msg, config, hooks, prepare-commit-msg",
+        ));
 }
 
 #[test]

--- a/tests/lint/test_single_rule.rs
+++ b/tests/lint/test_single_rule.rs
@@ -71,7 +71,7 @@ fn error_invalid_description_case() {
         .arg("add gitignore")
         .assert()
         .failure()
-        .stderr(contains("Unknown case"));
+        .stderr(contains("possible values: any, lower, upper"));
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn error_bad_output_format() {
         .arg("refactor(TheYellowArrow): Implement one-way journey")
         .assert()
         .failure()
-        .stderr(contains("Unknown format"));
+        .stderr(contains("possible values: cli, json, table, toml"));
 }
 
 #[test]


### PR DESCRIPTION
# 🐛 fix(cli): expose enum values to shell completions

## Summary

Expose the accepted values for `--init`, `--format`, and `--description-case` through Clap's command metadata. Generated shell completions now suggest the valid values instead of filenames, while CLI parsing remains case-insensitive.

This also:

- replaces the custom enum parsers with `ValueEnum`;
- removes the unused direct `strum` dependency;
- updates integration tests to verify the accepted value lists;
- checks that completion scripts can be generated for Bash, Elvish, Fish, PowerShell, and Zsh.

### Related issue

N/A

---

### How has this been tested?

- [x] Manual tests
- [ ] Unit tests
- [x] Integration tests

Validation performed:

- `cargo test`: 195 tests passed
- `cargo fmt --all -- --check`
- `cargo check --all-targets --locked`
- `cargo clippy --tests -- -D warnings`
- `cargo tarpaulin --engine llvm`: 96.86% coverage (957/988 lines)
- manual inspection of the generated Bash completion values

---

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

### Checklist

- [x] I have read the [**contributing guidelines**](https://github.com/welpo/git-sumi/blob/main/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I have formatted the code with `cargo fmt`.
